### PR TITLE
Update kriswallsmith/buzz requirement to use the current version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.3.2",
-        "kriswallsmith/buzz": "0.8",
+        "kriswallsmith/buzz": ">=0.8",
         "knplabs/knp-snappy": "0.1.*",
         "symfony/http-foundation": ">=2.1",
         "symfony/templating": ">=2.1",


### PR DESCRIPTION
Hi, 
I had to make a small change to be able to install hwi/oauth-bundle together with siphoc/PdfBundle. They both use kriswallsmith/buzz, only siphoc/PdfBundle was nailed to version 0.8 and hwi/oauth-bundle required 0.15
So I just updated the requirement from "0.8" to ">=0.8". As far as I was able to check kriswallsmith/buzz changelog, there's nothing serious there - mostly curl compatibility updates.

Cheers,
Vic
